### PR TITLE
Hide masthead on landing page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,23 +16,25 @@
   </head>
 
   <body>
-    <div class="wrapper-masthead">
-      <div class="container">
-        <header class="masthead clearfix">
-          <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
+    {% unless page.hide_masthead %}
+      <div class="wrapper-masthead">
+        <div class="container">
+          <header class="masthead clearfix">
+            <a href="{{ site.baseurl }}/" class="site-avatar"><img src="{{ site.avatar }}" /></a>
 
-          <div class="site-info">
-            <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
-            <p class="site-description">{{ site.description }}</p>
-          </div>
+            <div class="site-info">
+              <h1 class="site-name"><a href="{{ site.baseurl }}/">{{ site.name }}</a></h1>
+              <p class="site-description">{{ site.description }}</p>
+            </div>
 
-          <nav>
-            <a href="{{ site.baseurl }}/">Blog</a>
-            <a href="{{ site.baseurl }}/about">About</a>
-          </nav>
-        </header>
+            <nav>
+              <a href="{{ site.baseurl }}/">Blog</a>
+              <a href="{{ site.baseurl }}/about">About</a>
+            </nav>
+          </header>
+        </div>
       </div>
-    </div>
+    {% endunless %}
 
     <div id="main" role="main" class="container">
       {{ content }}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: "Home"
 permalink: /
+hide_masthead: true
 ---
 
 <style>


### PR DESCRIPTION
## Summary
- make the masthead optional via a new `hide_masthead` front matter flag in the default layout
- hide the masthead on the home page to remove the default Jekyll Now header copy

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caae4cbe348321a162f8bf14ee7919