### PR TITLE
Update homepage About section content

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,22 +51,13 @@ hide_masthead: true
   <div class="grid">
     <div class="card" style="grid-column: span 12;">
       <h3>About</h3>
-      <p>
-        I design and build reliable back‑end systems with a focus on scalability, high availability, and low latency. My day‑to‑day toolkit includes
-        <strong>Java&nbsp;(17)</strong>, <strong>Spring Boot</strong> (WebFlux & MVC), <strong>Kafka</strong>, <strong>Redis</strong>, and data stores such as <strong>PostgreSQL</strong> and <strong>MySQL</strong>.
-        In the cloud, I work across <strong>AWS</strong> services like API Gateway, Lambda, ECS, S3, and CloudWatch—shipping features with solid CI/CD, observability, and tests.
-      </p>
-      <div class="tags" aria-label="Key skills">
-        <span class="tag">Java 17</span>
-        <span class="tag">Spring Boot</span>
-        <span class="tag">WebFlux</span>
-        <span class="tag">Kafka</span>
-        <span class="tag">Redis</span>
-        <span class="tag">PostgreSQL</span>
-        <span class="tag">AWS</span>
-        <span class="tag">CI/CD</span>
-        <span class="tag">Testing & Monitoring</span>
-      </div>
+      <pre><code>#!/usr/bin/env bash
+echo "lam : Programmer | questioner | Idiot"
+University = Sai Gon University (SGU)
+Faculty = Information Technology
+Major = Software Engineering
+Skills = Java, Python # Most comfortable with
+</code></pre>
     </div>
 
     <div class="card" style="grid-column: span 12;">


### PR DESCRIPTION
## Summary
- replace the About section on the landing page with the provided script-style biography content

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb657124188321995747baaacba5cb