### PR TITLE
Create post layout navigation bar

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -2,6 +2,58 @@
 layout: default
 hide_masthead: true
 ---
+{% assign nav_site_title = site.name | default: site.title | default: site.description | default: site.github.repository_name %}
+<div class="post-masthead">
+  <div class="container">
+    <div class="post-masthead__inner">
+      {% if nav_site_title %}
+      <div class="post-masthead__brand" aria-label="Site">
+        <span class="post-masthead__brand-title">{{ nav_site_title | escape }}</span>
+      </div>
+      {% endif %}
+      <nav class="post-masthead__menu" aria-label="Primary navigation">
+        <a class="post-masthead__link{% if page.url == '/' %} post-masthead__link--active{% endif %}" href="{{ site.baseurl }}/"{% if page.url == '/' %} aria-current="page"{% endif %}>
+          <svg class="post-masthead__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M4 10.5L12 4l8 6.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+            <path d="M6 11.5v9h5v-5.5h2V20.5h5v-9" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+          </svg>
+          <span class="post-masthead__label">Home</span>
+        </a>
+        <a class="post-masthead__link" href="{{ site.baseurl }}/archives/">
+          <svg class="post-masthead__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <rect x="3.75" y="5" width="16.5" height="14.5" rx="2" ry="2" fill="none" stroke="currentColor" stroke-width="1.8"></rect>
+            <path d="M3.75 9h16.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+            <path d="M9 13h6" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+          </svg>
+          <span class="post-masthead__label">Archives</span>
+        </a>
+        <a class="post-masthead__link" href="{{ site.baseurl }}/categories/">
+          <svg class="post-masthead__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <rect x="4.25" y="4.25" width="7.5" height="7.5" rx="1.2" ry="1.2" fill="none" stroke="currentColor" stroke-width="1.8"></rect>
+            <rect x="12.25" y="4.25" width="7.5" height="7.5" rx="1.2" ry="1.2" fill="none" stroke="currentColor" stroke-width="1.8"></rect>
+            <rect x="4.25" y="12.25" width="7.5" height="7.5" rx="1.2" ry="1.2" fill="none" stroke="currentColor" stroke-width="1.8"></rect>
+            <rect x="12.25" y="12.25" width="7.5" height="7.5" rx="1.2" ry="1.2" fill="none" stroke="currentColor" stroke-width="1.8"></rect>
+          </svg>
+          <span class="post-masthead__label">Categories</span>
+        </a>
+        <a class="post-masthead__link{% if page.url == '/about/' or page.url == '/about' %} post-masthead__link--active{% endif %}" href="{{ site.baseurl }}/about/"{% if page.url == '/about/' or page.url == '/about' %} aria-current="page"{% endif %}>
+          <svg class="post-masthead__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="9" r="4" fill="none" stroke="currentColor" stroke-width="1.8"></circle>
+            <path d="M5.5 20c1.2-3 4.1-4.5 6.5-4.5s5.3 1.5 6.5 4.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></path>
+          </svg>
+          <span class="post-masthead__label">About</span>
+        </a>
+        <a class="post-masthead__link" href="{{ site.baseurl }}/search/">
+          <svg class="post-masthead__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="11" cy="11" r="5.5" fill="none" stroke="currentColor" stroke-width="1.8"></circle>
+            <line x1="16.2" y1="16.2" x2="20.5" y2="20.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"></line>
+          </svg>
+          <span class="post-masthead__label">Search</span>
+        </a>
+      </nav>
+    </div>
+  </div>
+</div>
 <article class="post">
   <header class="post-header">
     {% assign words = page.content | strip_html | number_of_words %}

--- a/style.scss
+++ b/style.scss
@@ -237,6 +237,121 @@ nav {
   }
 }
 
+.post-masthead {
+  background: #f5f5f5;
+  border-bottom: 1px solid #e3e3e3;
+  margin-bottom: 3rem;
+
+  @include mobile {
+    margin-bottom: 2.5rem;
+  }
+
+  &__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    flex-wrap: wrap;
+    padding: 1.4rem 0;
+
+    @include mobile {
+      flex-direction: column;
+      gap: 1.5rem;
+      text-align: center;
+    }
+  }
+
+  &__brand {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    color: $darkerGray;
+    font-family: $helveticaNeue;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: none;
+  }
+
+  &__brand::before,
+  &__brand::after {
+    content: "";
+    display: block;
+    width: 64px;
+    height: 2px;
+    border-radius: 9999px;
+    background: rgba($darkerGray, 0.8);
+  }
+
+  &__brand-title {
+    font-size: 1.2rem;
+    line-height: 1.3;
+    letter-spacing: inherit;
+  }
+
+  &__menu {
+    float: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: flex-end;
+    margin: 0;
+
+    @include mobile {
+      justify-content: center;
+    }
+  }
+
+  &__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: 9999px;
+    color: $darkGray;
+    font-family: $helveticaNeue;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+
+    @include mobile {
+      font-size: 0.95rem;
+    }
+  }
+
+  &__link:hover,
+  &__link:focus {
+    background: $lightGray;
+    color: $darkerGray;
+    box-shadow: 0 6px 16px rgba($black, 0.08);
+    text-decoration: none;
+    outline: none;
+  }
+
+  &__link--active {
+    background: $lightGray;
+    color: $darkerGray;
+    box-shadow: 0 6px 16px rgba($black, 0.08);
+  }
+
+  &__link:focus-visible {
+    outline: 2px solid lighten($blue, 15%);
+    outline-offset: 3px;
+  }
+
+  &__icon {
+    width: 1.2rem;
+    height: 1.2rem;
+    display: block;
+  }
+
+  &__label {
+    line-height: 1;
+    white-space: nowrap;
+  }
+}
+
 //
 // .main
 //


### PR DESCRIPTION
## Summary
- add a dedicated post masthead with navigation links and inline SVG icons
- style the post navigation bar to match the provided layout with decorative branding and hover states

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68cb7ed44c588321891eb4e8e68a9def