### PR TITLE
Hide masthead on post pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,3 +84,10 @@ exclude:
   - LICENSE
   - README.md
   - CNAME
+
+defaults:
+  - scope:
+      path: ""
+      type: posts
+    values:
+      hide_masthead: true


### PR DESCRIPTION
## Summary
- configure post pages to set `hide_masthead` so the default masthead is omitted

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb8326778c8321a6dd042224bcb729