### PR TITLE
Update hobby reading recommendations

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,11 +80,13 @@ Skills = Java, Python # Most comfortable with
           {% endfor %}
         </ul>
       {% else %}
-        <ul>
-          <li><strong>Risk Scoring Service</strong> — Reactive Spring service integrating Kafka, Redis, and a rules engine to compute risk segments in sub‑50ms.</li>
-          <li><strong>Document Upload API</strong> — S3‑backed presigned URL flow with CloudFront and signed headers; observability via CloudWatch dashboards.</li>
-          <li><strong>Settlement Quote Engine</strong> — Idempotent computation service with caching and circuit breakers, shipped via GitHub Actions to ECS Fargate.</li>
-        </ul>
+        <div class="hobby-reading">
+          <p><strong>Reading:</strong></p>
+          <ul>
+            <li>if you interested in Science &amp; Health: Why we sleep (Matthew Walker), Immune: A Journey into the Mysterious System That Keeps You Alive (Philipp Dettmer ), Thinking, Fast and Slow (Daniel Kahneman)</li>
+            <li>if you into some detective story, serial killer: The Silent of the lamb((Thomas Harris)), Hannibal (Thomas Harris)</li>
+          </ul>
+        </div>
       {% endif %}
     </div>
 


### PR DESCRIPTION
## Summary
- replace the default hobby section project list with curated reading suggestions
- highlight science, health, and detective/serial killer book recommendations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbc75475288321a61aeba3763fbb81