### PR TITLE
Add blog listing page

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,7 @@
             <nav>
               <a href="{{ site.baseurl }}/">Homepage</a>
               <a href="{{ site.baseurl }}/about">About</a>
+              <a href="{{ site.baseurl }}/blog/">Blog</a>
             </nav>
           </header>
         </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,0 +1,28 @@
+---
+layout: default
+title: Blog
+permalink: /blog/
+---
+
+<section class="blog-index">
+  <header class="blog-index__header">
+    <h1 class="blog-index__title">Blog</h1>
+    <p class="blog-index__intro">Stories, lessons, and notes from my journey as a software engineer.</p>
+  </header>
+
+  {% assign posts = site.posts %}
+  {% if posts and posts.size > 0 %}
+    <div class="posts blog-list">
+      {% for post in posts %}
+        <article class="post post--list">
+          <h2 class="post--list__title"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
+          <div class="post--list__meta">{{ post.date | date: "%b %d, %Y" }}{% if post.read_time %} &bull; {{ post.read_time }} min read{% endif %}</div>
+          <p class="post--list__excerpt">{{ post.excerpt | strip_html | truncate: 220 }}</p>
+          <a class="read-more" href="{{ post.url | relative_url }}">Read more &rarr;</a>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p class="blog-index__empty">No blog posts yet. Add one in <code>_posts/</code> to see it appear here.</p>
+  {% endif %}
+</section>

--- a/style.scss
+++ b/style.scss
@@ -366,6 +366,96 @@ nav {
   border-bottom: none;
 }
 
+.blog-index {
+  margin-bottom: 4rem;
+
+  &__header {
+    margin-bottom: 2.5rem;
+    text-align: center;
+
+    @include mobile {
+      margin-bottom: 2rem;
+    }
+  }
+
+  &__title {
+    margin: 0;
+    font-size: 2.4rem;
+  }
+
+  &__intro {
+    margin: 0.5rem auto 0;
+    max-width: 36rem;
+    color: $gray;
+    font-size: 1.05rem;
+    line-height: 1.6;
+  }
+
+  &__empty {
+    text-align: center;
+    color: $gray;
+    font-style: italic;
+  }
+}
+
+.blog-list {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.blog-list > .post {
+  padding: 1.9rem 2.2rem;
+  border: 1px solid lighten($lightGray, 8%);
+  border-radius: 18px;
+  border-bottom: none;
+  box-shadow: 0 18px 40px rgba($black, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background: $white;
+
+  @include mobile {
+    padding: 1.5rem 1.4rem;
+  }
+}
+
+.blog-list > .post:hover,
+.blog-list > .post:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 22px 55px rgba($black, 0.1);
+}
+
+.post--list__title {
+  margin: 0 0 0.5rem;
+  font-size: 1.95rem;
+
+  a {
+    color: $darkerGray;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+      color: $blue;
+    }
+  }
+}
+
+.post--list__meta {
+  margin-bottom: 0.9rem;
+  color: $gray;
+  font-size: 0.95rem;
+  letter-spacing: 0.01em;
+}
+
+.post--list__excerpt {
+  margin: 0 0 1.2rem;
+  color: $darkGray;
+  line-height: 1.6;
+}
+
+.blog-list .read-more {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
 .post {
   blockquote {
     margin: 1.8em .8em;


### PR DESCRIPTION
## Summary
- add a dedicated blog index page that lists all posts with excerpts and metadata
- style the blog listing with card-style previews for each post
- update the site navigation to link to the new blog page

## Testing
- jekyll -v *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd32b16ab483219d9490e07a08d757