### PR TITLE
Add resume page and update resume link

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@ hide_masthead: true
   <h1>{{ site.description | default: site.owner | default: site.title | default: "Your Name" }}</h1>
   <h2>Back-End Software Engineer — a.k.a. “Did you confirm that?” Engineer</h2>
   <div class="cta">
-    <a class="btn" href="{{ '/assets/resume.pdf' | relative_url }}">View Résumé</a>
+    <a class="btn" href="{{ '/resume/' | relative_url }}">View Résumé</a>
     <a class="btn btn-secondary" href="mailto:{{ site.email | default: 'you@example.com' }}">Contact</a>
     <a class="btn btn-secondary" href="{{ '/blog' | relative_url }}"> My Blogs</a>
   </div>

--- a/resume.html
+++ b/resume.html
@@ -1,0 +1,201 @@
+---
+layout: default
+title: "Résumé"
+permalink: /resume/
+---
+
+<div class="resume-page">
+  <header class="resume-header">
+    <div class="resume-headline">
+      <h1>Luong Vi Lam</h1>
+      <p class="resume-subtitle">Back-End Engineer</p>
+    </div>
+    <ul class="resume-contact">
+      <li><span aria-hidden="true">📞</span><a href="tel:+84834490692">0834 490 692</a></li>
+      <li><span aria-hidden="true">✉️</span><a href="mailto:luongvi2000@gmail.com">luongvi2000@gmail.com</a></li>
+      <li><span aria-hidden="true">📍</span>Ho Chi Minh City, Vietnam</li>
+    </ul>
+  </header>
+
+  <section class="resume-section">
+    <h2>Objective</h2>
+    <p>
+      I am a Software Engineer with nearly 3 years of experience in backend development, specializing in building
+      scalable and efficient systems using Java, Python, and modern frameworks like Spring and Serverless. Proven ability
+      to deliver robust solutions in agile environments, with a strong focus on cloud-based architectures and
+      microservices. Seeking to contribute to impactful projects and further grow technical expertise in a dynamic
+      engineering team.
+    </p>
+  </section>
+
+  <section class="resume-section">
+    <h2>Work Experience</h2>
+    <div class="resume-timeline">
+      <article class="resume-item">
+        <header>
+          <div class="resume-item__top">
+            <h3>Tymek Vietnam</h3>
+            <span class="resume-period">12/2023 – Present</span>
+          </div>
+          <div class="resume-item__meta">
+            <span class="resume-role">Software Engineer</span>
+            <span>Team size: 6 (Agile)</span>
+          </div>
+        </header>
+        <ul>
+          <li>Designed and implemented large-scale backend services, ensuring high system reliability, availability and resiliency.</li>
+          <li>Partnered cross-functionally to build robust test and release processes.</li>
+          <li>Led backend incident response to deliver high uptime.</li>
+        </ul>
+      </article>
+
+      <article class="resume-item">
+        <header>
+          <div class="resume-item__top">
+            <h3>Hitachi Vantara</h3>
+            <span class="resume-period">05/2023 – 12/2024</span>
+          </div>
+          <div class="resume-item__meta">
+            <span class="resume-role">Full-Stack Web Developer</span>
+          </div>
+        </header>
+        <ul>
+          <li>Designed and built reactive back-end systems for web applications.</li>
+          <li>Collaborated with cross-functional teams to deliver reliable features and refined user experiences.</li>
+          <li>Maintained and enhanced code quality through rigorous reviews and knowledge sharing.</li>
+        </ul>
+      </article>
+
+      <article class="resume-item">
+        <header>
+          <div class="resume-item__top">
+            <h3>SingPost (Legal Sports, Lottery, and Horse Racing Betting)</h3>
+            <span class="resume-period">11/2023 – 12/2024</span>
+          </div>
+          <div class="resume-item__meta">
+            <span class="resume-role">Java Back-End Engineer</span>
+            <span>Client: Singapore Pools • Team size: 10 (Agile)</span>
+          </div>
+        </header>
+        <ul>
+          <li>Designed betting payment and bet account management features to support the migration from monolithic architecture to a modern microservices-based system.</li>
+          <li>Implemented high-integrity settlement features using a domain event architecture.</li>
+          <li>Built account functionality within the new microservice architecture, ensuring stability and system cohesion.</li>
+          <li>Delivered services, APIs, and automated flow coverage to strengthen reliability and testability.</li>
+          <li>Evaluated emerging technologies to enhance the platform.</li>
+        </ul>
+        <p class="resume-tech"><strong>Technologies:</strong> Spring Boot, Spring Web, Spring WebFlux, Amazon RDS, PostgreSQL, DynamoDB, Redis.</p>
+      </article>
+
+      <article class="resume-item">
+        <header>
+          <div class="resume-item__top">
+            <h3>HCV-CRV (Factory Management Domain)</h3>
+            <span class="resume-period">03/2022 – 10/2023</span>
+          </div>
+          <div class="resume-item__meta">
+            <span class="resume-role">Java Back-End Engineer</span>
+            <span>Client: Japan • Team size: 7 (Agile)</span>
+          </div>
+        </header>
+        <ul>
+          <li>Built features for data integration across factory goods and visualized the integrated data for supply chain leaders.</li>
+          <li>Coordinated daily Kanban-based delivery and progress tracking.</li>
+          <li>Collaborated with stakeholders to define service flows and APIs aligned with business requirements.</li>
+          <li>Optimized data handling to support production dashboards and process monitoring.</li>
+        </ul>
+        <p class="resume-tech"><strong>Technologies:</strong> Java, Spring Boot, Spring Data JPA, Spring Security, PostgreSQL, DynamoDB, Kafka, MySQL.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="resume-section">
+    <h2>Projects</h2>
+    <div class="resume-timeline">
+      <article class="resume-item">
+        <header>
+          <div class="resume-item__top">
+            <h3>Personal Loan Platform (Lending)</h3>
+            <span class="resume-period">Company: TymeX Vietnam</span>
+          </div>
+          <div class="resume-item__meta">
+            <span class="resume-role">Software Engineer</span>
+            <span>Team size: 6 (Agile)</span>
+          </div>
+        </header>
+        <ul>
+          <li>Developed a proof-of-concept API to evaluate customer eligibility for loan applications.</li>
+          <li>Investigated SQL queries with TymeX Business and Data teams to review and assess backend performance.</li>
+          <li>Collaborated across the development team to align microservice architecture and implementation handoffs following the Saga pattern.</li>
+          <li>Documented handover artifacts to maintain 80% test coverage, ensuring code quality and stability.</li>
+          <li>Proactively learned key technologies for API development and integration.</li>
+        </ul>
+        <p class="resume-tech"><strong>Technologies:</strong> Amazon Web Services (AWS), Spring Framework (Spring Boot, Spring MVC, Spring Data JPA), Serverless, DynamoDB, PostgreSQL, Python, Node.js, Apache Kafka, Docker, OpenFeign, Flyway, CloudWatch, MySQL.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="resume-section resume-columns">
+    <div>
+      <h2>Education</h2>
+      <article class="resume-item resume-item--simple">
+        <div class="resume-item__top">
+          <h3>Bachelor of Information Technology</h3>
+          <span class="resume-period">2018 – 2022</span>
+        </div>
+        <p><strong>Sai Gon University</strong></p>
+        <p>Graduated with the relevant framework, technology for developing modern web applications.</p>
+      </article>
+
+      <h2>Additional Information</h2>
+      <ul class="resume-list">
+        <li><strong>LinkedIn:</strong> <a href="https://www.linkedin.com/in/luongvilam1701/">linkedin.com/in/luongvilam1701/</a></li>
+        <li><strong>GitHub:</strong> <a href="https://github.com/luongvilam123">github.com/luongvilam123</a></li>
+      </ul>
+
+      <h2>Certifications</h2>
+      <ul class="resume-list">
+        <li>Google Foundations of Project Management Certificate — 21/12/2023</li>
+        <li>English for Career Development Self-Paced MOOC 2023</li>
+        <li>TOEIC 930 (Listening &amp; Reading) — 17/01/2023</li>
+      </ul>
+    </div>
+
+    <div>
+      <h2>Skills</h2>
+      <dl class="resume-skills">
+        <div>
+          <dt>Programming Languages</dt>
+          <dd>Java, JavaScript, Python</dd>
+        </div>
+        <div>
+          <dt>Back-End Frameworks</dt>
+          <dd>Spring Boot, Spring MVC, Spring Data JPA</dd>
+        </div>
+        <div>
+          <dt>Front-End Frameworks</dt>
+          <dd>Angular, React.js, Material UI, Ant Design</dd>
+        </div>
+        <div>
+          <dt>System Design</dt>
+          <dd>Event-driven architectures, Microservices, Domain-Driven Design</dd>
+        </div>
+        <div>
+          <dt>Design Patterns</dt>
+          <dd>Saga, Observer, Factory, Singleton</dd>
+        </div>
+        <div>
+          <dt>Database &amp; Related Tools</dt>
+          <dd>MySQL, PostgreSQL, Elasticsearch, Flyway, MongoDB, Aurora</dd>
+        </div>
+        <div>
+          <dt>Tools</dt>
+          <dd>Jira, Confluence, GitHub, Bitbucket, Maven, Swagger</dd>
+        </div>
+      </dl>
+
+      <h2>Interests</h2>
+      <p>Likes reading books, playing sports, and learning about economics and finance.</p>
+    </div>
+  </section>
+</div>

--- a/style.scss
+++ b/style.scss
@@ -585,6 +585,234 @@ nav {
   }
 }
 
+//
+// Résumé page styles
+//
+
+.resume-page {
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(960px, calc(100vw - 3rem));
+  padding: 2.5rem 2rem 4rem;
+  background: $white;
+  color: $darkerGray;
+
+  @include mobile {
+    left: auto;
+    transform: none;
+    width: 100%;
+    padding: 2rem 0.5rem 3rem;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    color: $darkerGray;
+  }
+
+  h2 {
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 1.35rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h3 {
+    margin: 0;
+    font-size: 1.3rem;
+  }
+
+  p {
+    margin: 0 0 1rem;
+  }
+
+  ul {
+    margin: 0 0 1rem 1.25rem;
+  }
+
+  li {
+    margin-bottom: 0.4rem;
+  }
+
+  .resume-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1.75rem;
+    padding-bottom: 1.75rem;
+    border-bottom: 2px solid #e7e7e7;
+
+    @include mobile {
+      flex-direction: column;
+      gap: 1.2rem;
+      padding-bottom: 1.25rem;
+    }
+  }
+
+  .resume-headline h1 {
+    margin: 0;
+    font-size: clamp(2.2rem, 4vw, 2.8rem);
+    letter-spacing: -0.01em;
+  }
+
+  .resume-subtitle {
+    margin: 0.35rem 0 0;
+    font-size: 1.2rem;
+    font-weight: 500;
+    color: $gray;
+  }
+
+  .resume-contact {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+
+    @include mobile {
+      width: 100%;
+    }
+
+    li {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
+      margin: 0;
+    }
+
+    span {
+      font-size: 1.05rem;
+    }
+  }
+
+  .resume-section {
+    margin-top: 2.75rem;
+  }
+
+  .resume-timeline {
+    position: relative;
+    margin-left: 0.75rem;
+    padding-left: 1.5rem;
+    border-left: 2px solid #e5e5e5;
+
+    @include mobile {
+      margin-left: 0.25rem;
+      padding-left: 1rem;
+    }
+
+    .resume-item {
+      position: relative;
+      margin-bottom: 2.5rem;
+
+      &::before {
+        content: "";
+        position: absolute;
+        left: -1.64rem;
+        top: 0.5rem;
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        background: $white;
+        border: 3px solid $blue;
+
+        @include mobile {
+          left: -1.15rem;
+        }
+      }
+    }
+  }
+
+  .resume-item header {
+    margin-bottom: 0.75rem;
+  }
+
+  .resume-item__top {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .resume-period {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: $gray;
+  }
+
+  .resume-item__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 1rem;
+    font-size: 0.95rem;
+    color: $gray;
+  }
+
+  .resume-role {
+    font-weight: 600;
+    color: $darkerGray;
+  }
+
+  .resume-tech {
+    margin: 0.75rem 0 0;
+    font-size: 0.95rem;
+    color: $gray;
+
+    strong {
+      color: $darkerGray;
+    }
+  }
+
+  .resume-columns {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2rem 3rem;
+
+    @include mobile {
+      grid-template-columns: 1fr;
+      gap: 2rem;
+    }
+  }
+
+  .resume-item--simple {
+    margin-bottom: 1.75rem;
+  }
+
+  .resume-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1.5rem;
+    display: grid;
+    gap: 0.5rem;
+
+    strong {
+      font-weight: 600;
+      color: $darkerGray;
+    }
+  }
+
+  .resume-skills {
+    margin: 0 0 2rem;
+    display: grid;
+    gap: 0.8rem;
+
+    dt {
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+      color: $darkerGray;
+    }
+
+    dd {
+      margin: 0;
+      color: $gray;
+    }
+  }
+}
+
 .wrapper-footer {
   margin-top: 50px;
   border-top: 1px solid #ddd;


### PR DESCRIPTION
## Summary
- add a dedicated resume page that presents the provided CV content
- update the landing page resume button to link to the new page
- introduce resume-specific styling for layout, contact details, and timeline presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce3994178083218efe0b5762bde8d2