### PR TITLE
Restyle footer to match masthead

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,12 +21,11 @@ footer-links:
   email:
   facebook:
   flickr:
-  github: luongvilam123/luongvilam123.github.io
+  github: luongvilam123
   instagram:
-  linkedin:
+  linkedin: luongvilam1701
   pinterest:
   rss: # just type anything here for a working RSS icon
-  twitter: jekyllrb
   stackoverflow: # your stackoverflow profile, e.g. "users/50476/bart-kiers"
   youtube: # channel/<your_long_string> or user/<user-name>
   googleplus: # anything in your profile username that comes after plus.google.com/

--- a/_includes/svg-icons.html
+++ b/_includes/svg-icons.html
@@ -1,13 +1,72 @@
-{% if site.footer-links.dribbble %}<a href="https://dribbble.com/{{ site.footer-links.dribbble }}"><i class="svg-icon dribbble"></i></a>{% endif %}
-{% if site.footer-links.email %}<a href="mailto:{{ site.footer-links.email }}"><i class="svg-icon email"></i></a>{% endif %}
-{% if site.footer-links.facebook %}<a href="https://www.facebook.com/{{ site.footer-links.facebook }}"><i class="svg-icon facebook"></i></a>{% endif %}
-{% if site.footer-links.flickr %}<a href="https://www.flickr.com/{{ site.footer-links.flickr }}"><i class="svg-icon flickr"></i></a>{% endif %}
-{% if site.footer-links.github %}<a href="https://github.com/{{ site.footer-links.github }}"><i class="svg-icon github"></i></a>{% endif %}
-{% if site.footer-links.instagram %}<a href="https://instagram.com/{{ site.footer-links.instagram }}"><i class="svg-icon instagram"></i></a>{% endif %}
-{% if site.footer-links.linkedin %}<a href="https://www.linkedin.com/in/{{ site.footer-links.linkedin }}"><i class="svg-icon linkedin"></i></a>{% endif %}
-{% if site.footer-links.pinterest %}<a href="https://www.pinterest.com/{{ site.footer-links.pinterest }}"><i class="svg-icon pinterest"></i></a>{% endif %}
-{% if site.footer-links.rss %}<a href="{{ site.baseurl }}/feed.xml"><i class="svg-icon rss"></i></a>{% endif %}
-{% if site.footer-links.twitter %}<a href="https://www.twitter.com/{{ site.footer-links.twitter }}"><i class="svg-icon twitter"></i></a>{% endif %}
-{% if site.footer-links.stackoverflow %}<a href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}"><i class="svg-icon stackoverflow"></i></a>{% endif %}
-{% if site.footer-links.youtube %}<a href="https://youtube.com/{{ site.footer-links.youtube }}"><i class="svg-icon youtube"></i></a>{% endif %}
-{% if site.footer-links.googleplus %}<a href="https://plus.google.com/{{ site.footer-links.googleplus }}"><i class="svg-icon googleplus"></i></a>{% endif %}
+{% if site.footer-links.dribbble %}
+  <a class="site-footer__link" href="https://dribbble.com/{{ site.footer-links.dribbble }}" aria-label="Dribbble" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon dribbble" aria-hidden="true"></span>
+    <span class="site-footer__text">Dribbble</span>
+  </a>
+{% endif %}
+{% if site.footer-links.email %}
+  <a class="site-footer__link" href="mailto:{{ site.footer-links.email }}" aria-label="Email">
+    <span class="site-footer__icon svg-icon email" aria-hidden="true"></span>
+    <span class="site-footer__text">Email</span>
+  </a>
+{% endif %}
+{% if site.footer-links.facebook %}
+  <a class="site-footer__link" href="https://www.facebook.com/{{ site.footer-links.facebook }}" aria-label="Facebook" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon facebook" aria-hidden="true"></span>
+    <span class="site-footer__text">Facebook</span>
+  </a>
+{% endif %}
+{% if site.footer-links.flickr %}
+  <a class="site-footer__link" href="https://www.flickr.com/{{ site.footer-links.flickr }}" aria-label="Flickr" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon flickr" aria-hidden="true"></span>
+    <span class="site-footer__text">Flickr</span>
+  </a>
+{% endif %}
+{% if site.footer-links.github %}
+  <a class="site-footer__link" href="https://github.com/{{ site.footer-links.github }}" aria-label="GitHub" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon github" aria-hidden="true"></span>
+    <span class="site-footer__text">GitHub</span>
+  </a>
+{% endif %}
+{% if site.footer-links.instagram %}
+  <a class="site-footer__link" href="https://instagram.com/{{ site.footer-links.instagram }}" aria-label="Instagram" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon instagram" aria-hidden="true"></span>
+    <span class="site-footer__text">Instagram</span>
+  </a>
+{% endif %}
+{% if site.footer-links.linkedin %}
+  <a class="site-footer__link" href="https://www.linkedin.com/in/{{ site.footer-links.linkedin }}" aria-label="LinkedIn" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon linkedin" aria-hidden="true"></span>
+    <span class="site-footer__text">LinkedIn</span>
+  </a>
+{% endif %}
+{% if site.footer-links.pinterest %}
+  <a class="site-footer__link" href="https://www.pinterest.com/{{ site.footer-links.pinterest }}" aria-label="Pinterest" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon pinterest" aria-hidden="true"></span>
+    <span class="site-footer__text">Pinterest</span>
+  </a>
+{% endif %}
+{% if site.footer-links.rss %}
+  <a class="site-footer__link" href="{{ site.baseurl }}/feed.xml" aria-label="RSS">
+    <span class="site-footer__icon svg-icon rss" aria-hidden="true"></span>
+    <span class="site-footer__text">RSS</span>
+  </a>
+{% endif %}
+{% if site.footer-links.stackoverflow %}
+  <a class="site-footer__link" href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}" aria-label="Stack Overflow" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon stackoverflow" aria-hidden="true"></span>
+    <span class="site-footer__text">Stack Overflow</span>
+  </a>
+{% endif %}
+{% if site.footer-links.youtube %}
+  <a class="site-footer__link" href="https://youtube.com/{{ site.footer-links.youtube }}" aria-label="YouTube" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon youtube" aria-hidden="true"></span>
+    <span class="site-footer__text">YouTube</span>
+  </a>
+{% endif %}
+{% if site.footer-links.googleplus %}
+  <a class="site-footer__link" href="https://plus.google.com/{{ site.footer-links.googleplus }}" aria-label="Google Plus" rel="me noopener noreferrer" target="_blank">
+    <span class="site-footer__icon svg-icon googleplus" aria-hidden="true"></span>
+    <span class="site-footer__text">Google Plus</span>
+  </a>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,28 +10,28 @@
   </head>
 
   <body>
+    {% assign nav_site_title = site.name | default: site.title | default: site.description | default: site.github.repository_name %}
     {% unless page.hide_masthead %}
-     {% assign nav_site_title = site.name | default: site.title | default: site.description | default: site.github.repository_name %}
-<div class="post-masthead">
-  <div class="container">
-    <div class="post-masthead__inner">
-      {% if nav_site_title %}
-      <div class="post-masthead__brand" aria-label="Site">
-        <span class="post-masthead__brand-title">{{ nav_site_title | escape }}</span>
+      <div class="post-masthead">
+        <div class="container">
+          <div class="post-masthead__inner">
+            {% if nav_site_title %}
+            <div class="post-masthead__brand" aria-label="Site">
+              <span class="post-masthead__brand-title">{{ nav_site_title | escape }}</span>
+            </div>
+            {% endif %}
+            <nav class="post-masthead__menu" aria-label="Primary navigation">
+              <a class="post-masthead__link{% if page.url == '/' %} post-masthead__link--active{% endif %}" href="{{ site.baseurl }}/"{% if page.url == '/' %} aria-current="page"{% endif %}>
+                <svg class="post-masthead__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                  <path d="M4 10.5L12 4l8 6.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+                  <path d="M6 11.5v9h5v-5.5h2V20.5h5v-9" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
+                </svg>
+                <span class="post-masthead__label">Home</span>
+              </a>
+            </nav>
+          </div>
+        </div>
       </div>
-      {% endif %}
-      <nav class="post-masthead__menu" aria-label="Primary navigation">
-        <a class="post-masthead__link{% if page.url == '/' %} post-masthead__link--active{% endif %}" href="{{ site.baseurl }}/"{% if page.url == '/' %} aria-current="page"{% endif %}>
-          <svg class="post-masthead__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path d="M4 10.5L12 4l8 6.5" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-            <path d="M6 11.5v9h5v-5.5h2V20.5h5v-9" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"></path>
-          </svg>
-          <span class="post-masthead__label">Home</span>
-        </a>
-      </nav>
-    </div>
-  </div>
-</div>
     {% endunless %}
 
     <div id="main" role="main" class="container">
@@ -40,8 +40,17 @@
 
     <div class="wrapper-footer">
       <div class="container">
-        <footer class="footer">
-          {% include svg-icons.html %}
+        <footer class="site-footer" aria-label="Footer">
+          <div class="site-footer__inner">
+            {% if nav_site_title %}
+            <div class="site-footer__brand" aria-label="Site">
+              <span class="site-footer__brand-title">{{ nav_site_title | escape }}</span>
+            </div>
+            {% endif %}
+            <nav class="site-footer__links" aria-label="Social links">
+              {% include svg-icons.html %}
+            </nav>
+          </div>
         </footer>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -43,7 +43,6 @@ hide_masthead: true
   <div class="links">
     {% if site.github_username %}<a href="https://github.com/{{ site.github_username }}">GitHub</a>{% endif %}
     {% if site.linkedin %}<a href="{{ site.linkedin }}">LinkedIn</a>{% endif %}
-    {% if site.twitter %}<a href="https://twitter.com/{{ site.twitter }}">X/Twitter</a>{% endif %}
   </div>
 </header>
 

--- a/style.scss
+++ b/style.scss
@@ -814,15 +814,112 @@ nav {
 }
 
 .wrapper-footer {
-  margin-top: 50px;
-  border-top: 1px solid #ddd;
-  border-bottom: 1px solid #ddd;
-  background-color: $lightGray;
+  margin-top: 3rem;
+  background: #f5f5f5;
+  border-top: 1px solid #e3e3e3;
+
+  @include mobile {
+    margin-top: 2.5rem;
+  }
 }
 
-footer {
-  padding: 20px 0;
-  text-align: center;
+.site-footer {
+  padding: 1.4rem 0;
+
+  &__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    flex-wrap: wrap;
+
+    @include mobile {
+      flex-direction: column;
+      gap: 1.5rem;
+      text-align: center;
+    }
+  }
+
+  &__brand {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6rem;
+    color: $darkerGray;
+    font-family: $helveticaNeue;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+  }
+
+  &__brand::before,
+  &__brand::after {
+    content: "";
+    display: block;
+    width: 64px;
+    height: 2px;
+    border-radius: 9999px;
+    background: rgba($darkerGray, 0.8);
+  }
+
+  &__brand-title {
+    font-size: 1.2rem;
+    line-height: 1.3;
+    letter-spacing: inherit;
+  }
+
+  &__links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    justify-content: flex-end;
+    margin: 0;
+
+    @include mobile {
+      justify-content: center;
+    }
+  }
+
+  &__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: 9999px;
+    color: $darkGray;
+    font-family: $helveticaNeue;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  &__link:hover,
+  &__link:focus {
+    background: $lightGray;
+    color: $darkerGray;
+    box-shadow: 0 6px 16px rgba($black, 0.08);
+    text-decoration: none;
+    outline: none;
+  }
+
+  &__link:focus-visible {
+    outline: 2px solid lighten($blue, 15%);
+    outline-offset: 3px;
+  }
+
+  &__icon {
+    width: 1.4rem;
+    height: 1.4rem;
+    display: block;
+    background-size: contain;
+    background-repeat: no-repeat;
+    background-position: center;
+  }
+
+  &__text {
+    line-height: 1;
+    white-space: nowrap;
+  }
 }
 
 // Settled on moving the import of syntax highlighting to the bottom of the CSS


### PR DESCRIPTION
## Summary
- point the footer GitHub icon to the luongvilam123 profile
- swap the Twitter icon for a LinkedIn profile link
- remove the Twitter/X footer entry and hero link entirely
- restyle the footer to mirror the masthead layout and expose labeled social links

## Testing
- bundle exec jekyll serve --host 0.0.0.0 --port 4000 *(fails: Could not locate Gemfile or .bundle/ directory)*
- jekyll serve --host 0.0.0.0 --port 4000 *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68eb5162e0a88321989be29355a25e0a