### PR TITLE
Align footer layout with header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -41,10 +41,11 @@
     <div class="wrapper-footer">
       <div class="container">
         <footer class="site-footer" aria-label="Footer">
+          {% assign footer_brand_title = nav_site_title | default: '' | remove: 'LAM' | remove: 'Lam' | remove: 'lam' | strip %}
           <div class="site-footer__inner">
-            {% if nav_site_title %}
+            {% if footer_brand_title %}
             <div class="site-footer__brand" aria-label="Site">
-              <span class="site-footer__brand-title">{{ nav_site_title | escape }}</span>
+              <span class="site-footer__brand-title">{{ footer_brand_title | escape }}</span>
             </div>
             {% endif %}
             <nav class="site-footer__links" aria-label="Social links">

--- a/style.scss
+++ b/style.scss
@@ -833,6 +833,7 @@ nav {
     justify-content: space-between;
     gap: 2rem;
     flex-wrap: wrap;
+    width: 100%;
 
     @include mobile {
       flex-direction: column;
@@ -875,8 +876,10 @@ nav {
     align-items: center;
     justify-content: flex-end;
     margin: 0;
+    margin-left: auto;
 
     @include mobile {
+      margin-left: 0;
       justify-content: center;
     }
   }


### PR DESCRIPTION
## Summary
- strip the "LAM" substring from the footer brand title so the masthead text no longer appears in the footer
- ensure the footer flex container spans the full content width and keeps social links aligned with the header layout

## Testing
- ⚠️ `jekyll build` *(command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68eb58d5deec8321bf8f08671bf540a9