### PR TITLE
Limit footer social icons to GitHub and LinkedIn

### DIFF
--- a/_includes/svg-icons.html
+++ b/_includes/svg-icons.html
@@ -1,72 +1,12 @@
-{% if site.footer-links.dribbble %}
-  <a class="site-footer__link" href="https://dribbble.com/{{ site.footer-links.dribbble }}" aria-label="Dribbble" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon dribbble" aria-hidden="true"></span>
-    <span class="site-footer__text">Dribbble</span>
-  </a>
-{% endif %}
-{% if site.footer-links.email %}
-  <a class="site-footer__link" href="mailto:{{ site.footer-links.email }}" aria-label="Email">
-    <span class="site-footer__icon svg-icon email" aria-hidden="true"></span>
-    <span class="site-footer__text">Email</span>
-  </a>
-{% endif %}
-{% if site.footer-links.facebook %}
-  <a class="site-footer__link" href="https://www.facebook.com/{{ site.footer-links.facebook }}" aria-label="Facebook" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon facebook" aria-hidden="true"></span>
-    <span class="site-footer__text">Facebook</span>
-  </a>
-{% endif %}
-{% if site.footer-links.flickr %}
-  <a class="site-footer__link" href="https://www.flickr.com/{{ site.footer-links.flickr }}" aria-label="Flickr" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon flickr" aria-hidden="true"></span>
-    <span class="site-footer__text">Flickr</span>
-  </a>
-{% endif %}
 {% if site.footer-links.github %}
   <a class="site-footer__link" href="https://github.com/{{ site.footer-links.github }}" aria-label="GitHub" rel="me noopener noreferrer" target="_blank">
     <span class="site-footer__icon svg-icon github" aria-hidden="true"></span>
     <span class="site-footer__text">GitHub</span>
   </a>
 {% endif %}
-{% if site.footer-links.instagram %}
-  <a class="site-footer__link" href="https://instagram.com/{{ site.footer-links.instagram }}" aria-label="Instagram" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon instagram" aria-hidden="true"></span>
-    <span class="site-footer__text">Instagram</span>
-  </a>
-{% endif %}
 {% if site.footer-links.linkedin %}
   <a class="site-footer__link" href="https://www.linkedin.com/in/{{ site.footer-links.linkedin }}" aria-label="LinkedIn" rel="me noopener noreferrer" target="_blank">
     <span class="site-footer__icon svg-icon linkedin" aria-hidden="true"></span>
     <span class="site-footer__text">LinkedIn</span>
-  </a>
-{% endif %}
-{% if site.footer-links.pinterest %}
-  <a class="site-footer__link" href="https://www.pinterest.com/{{ site.footer-links.pinterest }}" aria-label="Pinterest" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon pinterest" aria-hidden="true"></span>
-    <span class="site-footer__text">Pinterest</span>
-  </a>
-{% endif %}
-{% if site.footer-links.rss %}
-  <a class="site-footer__link" href="{{ site.baseurl }}/feed.xml" aria-label="RSS">
-    <span class="site-footer__icon svg-icon rss" aria-hidden="true"></span>
-    <span class="site-footer__text">RSS</span>
-  </a>
-{% endif %}
-{% if site.footer-links.stackoverflow %}
-  <a class="site-footer__link" href="http://stackoverflow.com/{{ site.footer-links.stackoverflow }}" aria-label="Stack Overflow" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon stackoverflow" aria-hidden="true"></span>
-    <span class="site-footer__text">Stack Overflow</span>
-  </a>
-{% endif %}
-{% if site.footer-links.youtube %}
-  <a class="site-footer__link" href="https://youtube.com/{{ site.footer-links.youtube }}" aria-label="YouTube" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon youtube" aria-hidden="true"></span>
-    <span class="site-footer__text">YouTube</span>
-  </a>
-{% endif %}
-{% if site.footer-links.googleplus %}
-  <a class="site-footer__link" href="https://plus.google.com/{{ site.footer-links.googleplus }}" aria-label="Google Plus" rel="me noopener noreferrer" target="_blank">
-    <span class="site-footer__icon svg-icon googleplus" aria-hidden="true"></span>
-    <span class="site-footer__text">Google Plus</span>
   </a>
 {% endif %}

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -3,6 +3,9 @@
 // VARIABLES
 //
 
+// Layout
+$layout-max-width: 740px;
+
 // Colors
 $blue: #4183C4;
 

--- a/style.scss
+++ b/style.scss
@@ -25,7 +25,7 @@ body {
 
 .container {
   margin: 0 auto;
-  max-width: 740px;
+  max-width: $layout-max-width;
   padding: 0 10px;
   width: 100%;
 }
@@ -818,6 +818,13 @@ nav {
   margin-top: 3rem;
   background: #f5f5f5;
   border-top: 1px solid #e3e3e3;
+
+  > .container {
+    margin: 0 auto;
+    max-width: $layout-max-width;
+    padding: 0 10px;
+    width: 100%;
+  }
 
   @include mobile {
     margin-top: 2.5rem;


### PR DESCRIPTION
## Summary
- restrict the footer include to render only GitHub and LinkedIn social links
- reuse a shared layout max-width value so the footer container matches the header width

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68eb5b2d923c8321a1b8f810c6494fdc